### PR TITLE
Fix2：GitHub Actions で継続的インテグレーションを設定

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,58 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches-ignore:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  NODE_VERSION: "20.0.0"
+  PNPM_VERSION: "9.15.0"
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup environment
+        uses: ./.github/actions/setup
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+
+  lint:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+      - run: pnpm run lint
+
+  format:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+      - run: pnpm run format
+
+  typecheck:
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          pnpm-version: ${{ env.PNPM_VERSION }}
+      - run: pnpm run typecheck

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  NODE_VERSION: "20.0.0"
+  NODE_VERSION: "22.11.0"
   PNPM_VERSION: "9.15.0"
 
 jobs:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  NODE_VERSION: "22.11.0"
+  NODE_VERSION: "20.0.0"
   PNPM_VERSION: "9.15.0"
 
 jobs:
@@ -34,6 +34,8 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           pnpm-version: ${{ env.PNPM_VERSION }}
       - run: pnpm run lint
+        env:
+          DEBUG_URL: ${{ secrets.TEST_DEBUG_URL }}
 
   format:
     needs: setup


### PR DESCRIPTION
【エラー:lint】
Node.js v20.0.0
 ELIFECYCLE  Command failed with exit code 1.
Error: Process completed with exit code 1.

【解決】
.github/workflows/continuous-integration.yml ファイルに以下を追記。
```
env:
  DEBUG_URL: ${{ secrets.TEST_DEBUG_URL }}
```
